### PR TITLE
Add session creation form to dashboard

### DIFF
--- a/src/DbProxy/Dashboard/Controllers/DashboardController.cs
+++ b/src/DbProxy/Dashboard/Controllers/DashboardController.cs
@@ -13,14 +13,16 @@ namespace DbProxy.Dashboard.Controllers;
 public class DashboardController : Controller
 {
     private readonly SessionManager _sessionManager;
+    private readonly JwtAuthenticator _jwtAuth;
     private readonly QueryLogger _queryLogger;
     private readonly ProxyConfig _config;
     private readonly SettingsStore _settingsStore;
     private readonly SetupState _setupState;
 
-    public DashboardController(SessionManager sessionManager, QueryLogger queryLogger, ProxyConfig config, SettingsStore settingsStore, SetupState setupState)
+    public DashboardController(SessionManager sessionManager, JwtAuthenticator jwtAuth, QueryLogger queryLogger, ProxyConfig config, SettingsStore settingsStore, SetupState setupState)
     {
         _sessionManager = sessionManager;
+        _jwtAuth = jwtAuth;
         _queryLogger = queryLogger;
         _config = config;
         _settingsStore = settingsStore;
@@ -136,6 +138,42 @@ public class DashboardController : Controller
     {
         Response.Cookies.Delete("gatesql_key");
         return RedirectToAction("Login");
+    }
+
+    [HttpGet("/dashboard/sessions/new")]
+    public IActionResult CreateSessionForm()
+    {
+        return PartialView("_CreateSessionForm");
+    }
+
+    [HttpPost("/dashboard/sessions/create")]
+    public IActionResult CreateSession(string agentId, string task, int? queryBudget, bool readOnly, string dangerousQueryMode, string? allowedTables)
+    {
+        var sessionId = $"sess_{Guid.NewGuid():N}";
+        var lifetime = TimeSpan.FromMinutes(_config.Auth.HardCapMinutes);
+        var expiresAt = DateTime.UtcNow.Add(lifetime);
+
+        var parsedTables = string.IsNullOrWhiteSpace(allowedTables)
+            ? null
+            : allowedTables.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+        _sessionManager.CreateSession(
+            sessionId, agentId, task, queryBudget, expiresAt,
+            readOnly, dangerousQueryMode ?? "block", parsedTables);
+
+        var token = _jwtAuth.GenerateToken(sessionId, agentId, task, queryBudget, lifetime);
+
+        var host = _config.Proxy.ListenHost == "0.0.0.0" ? "localhost" : _config.Proxy.ListenHost;
+        var port = _config.Proxy.ListenPort;
+        var database = _config.Upstream.Database;
+
+        ViewBag.SessionId = sessionId;
+        ViewBag.Token = token;
+        ViewBag.ExpiresAt = expiresAt;
+        ViewBag.ConnectionString = $"postgresql://agent:{Uri.EscapeDataString(token)}@{host}:{port}/{database}";
+        ViewBag.PsqlCommand = $"PGPASSWORD=\"{token}\" psql -h {host} -p {port} -U agent -d {database}";
+
+        return PartialView("_SessionCreated");
     }
 
     [HttpPost("/dashboard/revoke/{sessionId}")]

--- a/src/DbProxy/Dashboard/Views/Dashboard/Index.cshtml
+++ b/src/DbProxy/Dashboard/Views/Dashboard/Index.cshtml
@@ -16,8 +16,21 @@
         @await Html.PartialAsync("_Stats", Model)
     </div>
 
+    <div id="session-form-area">
+        @if (Model.ActiveSessions.Count == 0)
+        {
+            @await Html.PartialAsync("_CreateSessionForm")
+        }
+    </div>
+
     <div class="section">
-        <h2>Sessions</h2>
+        <div class="section-header">
+            <h2>Sessions</h2>
+            <button class="btn-new-session"
+                    hx-get="/dashboard/sessions/new"
+                    hx-target="#session-form-area"
+                    hx-swap="innerHTML">+ New Session</button>
+        </div>
         <table>
             <thead>
                 <tr>

--- a/src/DbProxy/Dashboard/Views/Dashboard/Setup.cshtml
+++ b/src/DbProxy/Dashboard/Views/Dashboard/Setup.cshtml
@@ -14,17 +14,8 @@
     .api-key-box button { background: #1a1a1a; border: 1px solid #333; color: #a3a3a3; padding: 6px 12px; border-radius: 4px; font-size: 12px; cursor: pointer; white-space: nowrap; }
     .api-key-box button:hover { color: #e5e5e5; border-color: #525252; }
     .api-key-hint { font-size: 12px; color: #525252; }
-    .form-group { margin-bottom: 12px; }
-    .form-group label { display: block; font-size: 12px; color: #a3a3a3; margin-bottom: 4px; }
-    .form-group input, .form-group select { width: 100%; background: #111; border: 1px solid #1a1a1a; color: #e5e5e5; padding: 10px 12px; border-radius: 6px; font-size: 14px; font-family: inherit; }
-    .form-group input:focus, .form-group select:focus { outline: none; border-color: #333; }
-    .form-group select { appearance: none; }
-    .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-    .btn-primary { background: #e5e5e5; color: #0a0a0a; border: none; padding: 10px 20px; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; width: 100%; }
-    .btn-primary:hover { background: #d4d4d4; }
-    .btn-secondary { background: transparent; color: #a3a3a3; border: 1px solid #1a1a1a; padding: 10px 20px; border-radius: 6px; font-size: 14px; cursor: pointer; width: 100%; }
-    .btn-secondary:hover { color: #e5e5e5; border-color: #333; }
     .btn-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-top: 20px; }
+    .btn-row .btn-primary, .btn-row .btn-secondary { width: 100%; }
     .test-result { margin-top: 12px; padding: 12px; border-radius: 6px; font-size: 13px; }
     .test-result.success { background: #052e16; color: #4ade80; border: 1px solid #166534; }
     .test-result.failure { background: #2a0a0a; color: #f87171; border: 1px solid #7f1d1d; }

--- a/src/DbProxy/Dashboard/Views/Dashboard/_CreateSessionForm.cshtml
+++ b/src/DbProxy/Dashboard/Views/Dashboard/_CreateSessionForm.cshtml
@@ -1,0 +1,49 @@
+<div class="session-form">
+    <h3>Create Agent Session</h3>
+    <p class="form-subtitle">Generate a short-lived JWT for an AI agent to connect via PostgreSQL wire protocol.</p>
+
+    <form hx-post="/dashboard/sessions/create" hx-target="#session-form-area" hx-swap="innerHTML">
+        <div class="form-row">
+            <div class="form-group">
+                <label>Agent ID</label>
+                <input type="text" name="agentId" required placeholder="my-agent">
+            </div>
+            <div class="form-group">
+                <label>Task</label>
+                <input type="text" name="task" required placeholder="Analyze sales data">
+            </div>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label>Query Budget</label>
+                <input type="number" name="queryBudget" min="1" placeholder="Unlimited">
+            </div>
+            <div class="form-group">
+                <label>Dangerous Query Mode</label>
+                <select name="dangerousQueryMode">
+                    <option value="block" selected>Block</option>
+                    <option value="warn">Warn</option>
+                    <option value="allow">Allow</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label>Allowed Tables</label>
+            <input type="text" name="allowedTables" placeholder="e.g. public.orders, public.products">
+        </div>
+
+        <div class="form-group">
+            <label class="toggle-label">
+                <input type="checkbox" name="readOnly" value="true">
+                <span>Read-only session</span>
+            </label>
+        </div>
+
+        <div class="form-actions">
+            <button type="submit" class="btn-primary">Create Session</button>
+            <button type="button" class="btn-secondary" onclick="document.getElementById('session-form-area').innerHTML=''">Cancel</button>
+        </div>
+    </form>
+</div>

--- a/src/DbProxy/Dashboard/Views/Dashboard/_SessionCreated.cshtml
+++ b/src/DbProxy/Dashboard/Views/Dashboard/_SessionCreated.cshtml
@@ -1,0 +1,42 @@
+<div class="credential-card">
+    <div class="credential-header">
+        <span class="badge badge-green">Session Created</span>
+        <span class="credential-session-id">@ViewBag.SessionId</span>
+    </div>
+
+    <div class="credential-row">
+        <label>Token (PGPASSWORD)</label>
+        <div class="credential-value">
+            <code id="cred-token">@ViewBag.Token</code>
+            <button class="btn-copy" onclick="navigator.clipboard.writeText(document.getElementById('cred-token').textContent)">Copy</button>
+        </div>
+    </div>
+
+    <div class="credential-row">
+        <label>Connection String</label>
+        <div class="credential-value">
+            <code id="cred-connstr">@ViewBag.ConnectionString</code>
+            <button class="btn-copy" onclick="navigator.clipboard.writeText(document.getElementById('cred-connstr').textContent)">Copy</button>
+        </div>
+    </div>
+
+    <div class="credential-row">
+        <label>psql Command</label>
+        <div class="credential-value">
+            <code id="cred-psql">@ViewBag.PsqlCommand</code>
+            <button class="btn-copy" onclick="navigator.clipboard.writeText(document.getElementById('cred-psql').textContent)">Copy</button>
+        </div>
+    </div>
+
+    <div class="credential-row">
+        <label>Expires</label>
+        <div class="credential-value">
+            <code>@ViewBag.ExpiresAt.ToString("yyyy-MM-dd HH:mm:ss") UTC</code>
+        </div>
+    </div>
+
+    <div class="form-actions">
+        <button class="btn-primary" hx-get="/dashboard/sessions/new" hx-target="#session-form-area" hx-swap="innerHTML">Create Another</button>
+        <button class="btn-secondary" onclick="document.getElementById('session-form-area').innerHTML=''">Done</button>
+    </div>
+</div>

--- a/src/DbProxy/Dashboard/Views/Dashboard/_SessionsTable.cshtml
+++ b/src/DbProxy/Dashboard/Views/Dashboard/_SessionsTable.cshtml
@@ -2,7 +2,7 @@
 
 @if (Model.ActiveSessions.Count == 0)
 {
-    <tr><td colspan="9" class="empty">No active sessions</td></tr>
+    <tr><td colspan="9" class="empty">No active sessions — create one above</td></tr>
 }
 @foreach (var s in Model.ActiveSessions)
 {

--- a/src/DbProxy/Dashboard/Views/Shared/_Layout.cshtml
+++ b/src/DbProxy/Dashboard/Views/Shared/_Layout.cshtml
@@ -30,6 +30,35 @@
         .stat-card .label { font-size: 12px; color: #737373; margin-bottom: 4px; }
         .stat-card .value { font-size: 24px; font-weight: 600; font-variant-numeric: tabular-nums; }
         .empty { padding: 32px; text-align: center; color: #525252; font-size: 13px; }
+        .form-group { margin-bottom: 12px; }
+        .form-group label { display: block; font-size: 12px; color: #a3a3a3; margin-bottom: 4px; }
+        .form-group input, .form-group select { width: 100%; background: #111; border: 1px solid #1a1a1a; color: #e5e5e5; padding: 10px 12px; border-radius: 6px; font-size: 14px; font-family: inherit; }
+        .form-group input:focus, .form-group select:focus { outline: none; border-color: #333; }
+        .form-group select { appearance: none; }
+        .form-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+        .btn-primary { background: #e5e5e5; color: #0a0a0a; border: none; padding: 10px 20px; border-radius: 6px; font-size: 14px; font-weight: 500; cursor: pointer; }
+        .btn-primary:hover { background: #d4d4d4; }
+        .btn-secondary { background: transparent; color: #a3a3a3; border: 1px solid #1a1a1a; padding: 10px 20px; border-radius: 6px; font-size: 14px; cursor: pointer; }
+        .btn-secondary:hover { color: #e5e5e5; border-color: #333; }
+        .form-actions { display: flex; gap: 12px; margin-top: 20px; }
+        .section-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+        .section-header h2 { margin-bottom: 0; }
+        .btn-new-session { background: #052e16; color: #4ade80; border: 1px solid #166534; padding: 5px 14px; border-radius: 6px; font-size: 12px; font-weight: 500; cursor: pointer; }
+        .btn-new-session:hover { background: #166534; }
+        .session-form { background: #111; border: 1px solid #1a1a1a; border-radius: 8px; padding: 24px; max-width: 560px; margin-bottom: 32px; }
+        .session-form h3 { font-size: 16px; font-weight: 600; margin-bottom: 4px; }
+        .form-subtitle { font-size: 13px; color: #737373; margin-bottom: 20px; }
+        .toggle-label { display: flex; align-items: center; gap: 8px; cursor: pointer; font-size: 13px; color: #e5e5e5; }
+        .toggle-label input[type="checkbox"] { accent-color: #4ade80; width: 16px; height: 16px; }
+        .credential-card { background: #111; border: 1px solid #166534; border-radius: 8px; padding: 24px; max-width: 560px; margin-bottom: 32px; }
+        .credential-header { display: flex; align-items: center; gap: 12px; margin-bottom: 20px; }
+        .credential-session-id { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; color: #525252; }
+        .credential-row { margin-bottom: 16px; }
+        .credential-row label { display: block; font-size: 11px; color: #737373; text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 6px; }
+        .credential-value { display: flex; align-items: flex-start; gap: 8px; background: #0a0a0a; border: 1px solid #1a1a1a; border-radius: 6px; padding: 10px 12px; }
+        .credential-value code { font-family: 'SF Mono', 'Fira Code', monospace; font-size: 12px; color: #4ade80; flex: 1; word-break: break-all; line-height: 1.5; }
+        .btn-copy { background: #1a1a1a; border: 1px solid #333; color: #a3a3a3; padding: 4px 10px; border-radius: 4px; font-size: 11px; cursor: pointer; white-space: nowrap; flex-shrink: 0; }
+        .btn-copy:hover { color: #e5e5e5; border-color: #525252; }
         .btn-revoke { background: #2a0a0a; color: #f87171; border: 1px solid #3a1a1a; padding: 3px 10px; border-radius: 4px; font-size: 11px; cursor: pointer; }
         .btn-revoke:hover { background: #3a1a1a; }
         .login-container { max-width: 360px; margin: 120px auto; padding: 32px; }

--- a/src/DbProxy/Program.cs
+++ b/src/DbProxy/Program.cs
@@ -118,6 +118,7 @@ var queryLogger = new QueryLogger(dbFactory);
 
 // Register services for MVC DI
 builder.Services.AddSingleton(config);
+builder.Services.AddSingleton(jwtAuth);
 builder.Services.AddSingleton(sessionManager);
 builder.Services.AddSingleton(queryLogger);
 builder.Services.AddSingleton(settingsStore);

--- a/tests/DbProxy.Tests/Integration/DashboardFixture.cs
+++ b/tests/DbProxy.Tests/Integration/DashboardFixture.cs
@@ -1,0 +1,163 @@
+using System.Net;
+using DbProxy.Auth;
+using DbProxy.Configuration;
+using DbProxy.Dashboard;
+using DbProxy.Dashboard.Controllers;
+using DbProxy.Data;
+using DbProxy.Protocol;
+using DbProxy.Query;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.PostgreSql;
+
+namespace DbProxy.Tests.Integration;
+
+public class DashboardFixture : IAsyncLifetime
+{
+    public ProxyConfig Config { get; private set; } = null!;
+    public int ProxyPort { get; private set; }
+    public int ApiPort { get; private set; }
+    public string ApiKey => "test_key_123";
+
+    private PostgreSqlContainer _pg = null!;
+    private PgProtocolHandler _pgHandler = null!;
+    private WebApplication _webApp = null!;
+    private JwtAuthenticator _jwtAuth = null!;
+    private SessionManager _sessionManager = null!;
+    private QueryLogger _queryLogger = null!;
+    private CancellationTokenSource _cts = null!;
+    private string _tempDir = null!;
+
+    public async Task InitializeAsync()
+    {
+        _pg = new PostgreSqlBuilder("postgres:17")
+            .WithUsername("testuser")
+            .WithPassword("testpass")
+            .Build();
+        await _pg.StartAsync();
+
+        _tempDir = Path.Combine(Path.GetTempPath(), $"dbproxy-dashboard-test-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        ProxyPort = GetFreePort();
+        ApiPort = GetFreePort();
+
+        Config = new ProxyConfig
+        {
+            Proxy = new ProxySettings { ListenPort = ProxyPort, ListenHost = "0.0.0.0" },
+            Upstream = new UpstreamSettings
+            {
+                Host = _pg.Hostname,
+                Port = _pg.GetMappedPublicPort(5432),
+                Database = "postgres",
+                Username = "testuser",
+                Password = "testpass",
+            },
+            Auth = new AuthSettings
+            {
+                HardCapMinutes = 60,
+                IdleTimeoutMinutes = 5,
+                SigningKeyPath = Path.Combine(_tempDir, "signing.key"),
+                ParentApiKeys = [new ParentApiKey { Name = "test", Key = ApiKey }],
+            },
+            Logging = new LoggingSettings { Directory = Path.Combine(_tempDir, "logs") },
+            Dashboard = new DashboardSettings { Enabled = true, Port = ApiPort },
+        };
+
+        var signingKeyManager = new SigningKeyManager(Config.Auth.SigningKeyPath);
+        _jwtAuth = new JwtAuthenticator(signingKeyManager);
+        _sessionManager = new SessionManager(TimeSpan.FromMinutes(Config.Auth.IdleTimeoutMinutes));
+        _queryLogger = new QueryLogger();
+
+        // Initialize SQLite for SettingsStore
+        var dbPath = Path.Combine(_tempDir, "test.db");
+        var dbOptions = new DbContextOptionsBuilder<GateSqlDbContext>()
+            .UseSqlite($"Data Source={dbPath}")
+            .Options;
+        await using (var initDb = new GateSqlDbContext(dbOptions))
+            await initDb.Database.EnsureCreatedAsync();
+
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls($"http://127.0.0.1:{ApiPort}");
+        builder.Logging.SetMinimumLevel(LogLevel.Warning);
+
+        builder.Services.AddDbContextFactory<GateSqlDbContext>(options =>
+            options.UseSqlite($"Data Source={dbPath}"));
+
+        builder.Services.AddSingleton(Config);
+        builder.Services.AddSingleton(_jwtAuth);
+        builder.Services.AddSingleton(_sessionManager);
+        builder.Services.AddSingleton(_queryLogger);
+        builder.Services.AddSingleton(new SetupState { SetupRequired = false });
+
+        // Build a temporary ServiceProvider to create SettingsStore
+        var tempSp = builder.Services.BuildServiceProvider();
+        var dbFactory = tempSp.GetRequiredService<IDbContextFactory<GateSqlDbContext>>();
+        var settingsStore = new SettingsStore(dbFactory);
+        await settingsStore.InitializeAsync();
+        builder.Services.AddSingleton(settingsStore);
+
+        builder.Services.AddControllersWithViews()
+            .AddApplicationPart(typeof(DashboardController).Assembly)
+            .AddRazorOptions(options =>
+            {
+                options.ViewLocationFormats.Clear();
+                options.ViewLocationFormats.Add("/Dashboard/Views/{1}/{0}.cshtml");
+                options.ViewLocationFormats.Add("/Dashboard/Views/Shared/{0}.cshtml");
+            });
+
+        _webApp = builder.Build();
+
+        _webApp.UseStaticFiles(new StaticFileOptions
+        {
+            FileProvider = new Microsoft.Extensions.FileProviders.PhysicalFileProvider(
+                Path.Combine(AppContext.BaseDirectory, "Dashboard", "wwwroot")),
+        });
+
+        DbProxy.Api.AdminApiEndpoints.MapAdminApi(_webApp, Config, _jwtAuth, _sessionManager, _queryLogger);
+        _webApp.MapControllerRoute(name: "default", pattern: "{controller=Dashboard}/{action=Index}/{id?}");
+
+        _cts = new CancellationTokenSource();
+
+        var loggerFactory = LoggerFactory.Create(b => b.AddConsole().SetMinimumLevel(LogLevel.Debug));
+        _pgHandler = new PgProtocolHandler(Config, _jwtAuth, _sessionManager, _queryLogger,
+            loggerFactory.CreateLogger<PgProtocolHandler>());
+
+        _ = Task.Run(() => _pgHandler.StartAsync(_cts.Token));
+        _ = Task.Run(() => _webApp.RunAsync(_cts.Token));
+
+        await Task.Delay(500);
+    }
+
+    public HttpClient CreateAuthenticatedClient()
+    {
+        var cookies = new CookieContainer();
+        cookies.Add(new Uri($"http://127.0.0.1:{ApiPort}"), new Cookie("gatesql_key", ApiKey));
+        var handler = new HttpClientHandler { CookieContainer = cookies, AllowAutoRedirect = false };
+        return new HttpClient(handler) { BaseAddress = new Uri($"http://127.0.0.1:{ApiPort}") };
+    }
+
+    public string BuildConnectionString(string token)
+    {
+        return $"Host=127.0.0.1;Port={ProxyPort};Database=postgres;Username=agent;Password={token}";
+    }
+
+    public async Task DisposeAsync()
+    {
+        _cts.Cancel();
+        _pgHandler.Dispose();
+        _sessionManager.Dispose();
+        _queryLogger.Dispose();
+        await _webApp.DisposeAsync();
+        await _pg.DisposeAsync();
+        try { Directory.Delete(_tempDir, true); } catch { }
+    }
+
+    private static int GetFreePort()
+    {
+        var listener = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((System.Net.IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}

--- a/tests/DbProxy.Tests/Integration/DashboardSessionTests.cs
+++ b/tests/DbProxy.Tests/Integration/DashboardSessionTests.cs
@@ -1,0 +1,130 @@
+using System.Net;
+using Npgsql;
+
+namespace DbProxy.Tests.Integration;
+
+public class DashboardSessionTests : IAsyncLifetime
+{
+    private readonly DashboardFixture _fixture = new();
+
+    public Task InitializeAsync() => _fixture.InitializeAsync();
+    public Task DisposeAsync() => _fixture.DisposeAsync();
+
+    [Fact]
+    public async Task CreateSessionForm_ReturnsFormHtml()
+    {
+        using var http = _fixture.CreateAuthenticatedClient();
+        var response = await http.GetAsync("/dashboard/sessions/new");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("agentId", html);
+        Assert.Contains("queryBudget", html);
+        Assert.Contains("dangerousQueryMode", html);
+        Assert.Contains("Create Session", html);
+    }
+
+    [Fact]
+    public async Task CreateSession_ReturnsCredentials()
+    {
+        using var http = _fixture.CreateAuthenticatedClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["agentId"] = "dashboard-test-agent",
+            ["task"] = "integration-test",
+            ["queryBudget"] = "50",
+            ["readOnly"] = "true",
+            ["dangerousQueryMode"] = "block",
+        });
+        var response = await http.PostAsync("/dashboard/sessions/create", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Session Created", html);
+        Assert.Contains("sess_", html);
+        Assert.Contains("PGPASSWORD", html);
+        Assert.Contains("postgresql://agent:", html);
+    }
+
+    [Fact]
+    public async Task CreateSession_TokenIsUsable()
+    {
+        using var http = _fixture.CreateAuthenticatedClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["agentId"] = "token-test-agent",
+            ["task"] = "verify-token",
+        });
+        var response = await http.PostAsync("/dashboard/sessions/create", form);
+        var html = await response.Content.ReadAsStringAsync();
+
+        // Extract token from the HTML (it's in a <code id="cred-token"> element)
+        var tokenStart = html.IndexOf("id=\"cred-token\">") + "id=\"cred-token\">".Length;
+        var tokenEnd = html.IndexOf("</code>", tokenStart);
+        var token = html[tokenStart..tokenEnd];
+
+        Assert.NotEmpty(token);
+
+        // Use token to connect through proxy
+        var connStr = _fixture.BuildConnectionString(token);
+        await using var conn = new NpgsqlConnection(connStr);
+        await conn.OpenAsync();
+
+        await using var cmd = new NpgsqlCommand("/* <agent_purpose>dashboard test</agent_purpose> */ SELECT 42", conn);
+        var result = await cmd.ExecuteScalarAsync();
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public async Task CreateSession_WithAllowedTables_ParsesCorrectly()
+    {
+        using var http = _fixture.CreateAuthenticatedClient();
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["agentId"] = "tables-test",
+            ["task"] = "table-test",
+            ["allowedTables"] = "public.orders, public.products",
+        });
+        var response = await http.PostAsync("/dashboard/sessions/create", form);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Session Created", html);
+
+        // Verify via API that tables were parsed
+        using var apiHttp = new HttpClient();
+        apiHttp.DefaultRequestHeaders.Add("X-Api-Key", _fixture.ApiKey);
+        var sessionsResponse = await apiHttp.GetAsync($"http://127.0.0.1:{_fixture.ApiPort}/api/sessions");
+        var body = await sessionsResponse.Content.ReadAsStringAsync();
+        Assert.Contains("public.orders", body);
+        Assert.Contains("public.products", body);
+    }
+
+    [Fact]
+    public async Task CreateSession_WithoutAuth_RedirectsToLogin()
+    {
+        using var http = new HttpClient(new HttpClientHandler { AllowAutoRedirect = false });
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["agentId"] = "unauth-test",
+            ["task"] = "test",
+        });
+        var response = await http.PostAsync($"http://127.0.0.1:{_fixture.ApiPort}/dashboard/sessions/create", form);
+
+        Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);
+        Assert.Contains("login", response.Headers.Location?.ToString() ?? "", StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Dashboard_EmptyState_ShowsForm()
+    {
+        using var http = _fixture.CreateAuthenticatedClient();
+        var response = await http.GetAsync("/dashboard");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var html = await response.Content.ReadAsStringAsync();
+        // Empty state should show the create session form
+        Assert.Contains("Create Agent Session", html);
+        Assert.Contains("No active sessions", html);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a create session form to the MVC dashboard, eliminating the need for curl to create agent sessions
- Form appears as an empty-state welcome card when no sessions exist, and via a "+ New Session" button when sessions are present
- On submit, displays credentials (token, connection string, psql command) with copy-to-clipboard buttons
- Shared form CSS extracted from Setup page into global layout

## Test plan
- [x] 6 new integration tests covering form rendering, session creation, token usability, allowed tables parsing, auth redirect, and empty state display
- [x] All 103 tests pass (48 unit + 55 integration)
- [ ] Manual: verify empty-state welcome card renders correctly
- [ ] Manual: verify "+ New Session" button works when sessions exist
- [ ] Manual: verify copy buttons work
- [ ] Manual: verify created session token connects successfully

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)