### PR TITLE
Fix query budget overcount display

### DIFF
--- a/src/DbProxy/Auth/SessionManager.cs
+++ b/src/DbProxy/Auth/SessionManager.cs
@@ -155,11 +155,10 @@ public class SessionManager : IDisposable
         if (!_sessions.TryGetValue(sessionId, out var session))
             return false;
 
-        session.QueriesUsed++;
-
-        if (session.QueryBudget.HasValue && session.QueriesUsed > session.QueryBudget.Value)
+        if (session.QueryBudget.HasValue && session.QueriesUsed >= session.QueryBudget.Value)
             return false;
 
+        session.QueriesUsed++;
         return true;
     }
 

--- a/tests/DbProxy.Tests/Unit/SessionManagerTests.cs
+++ b/tests/DbProxy.Tests/Unit/SessionManagerTests.cs
@@ -1,0 +1,102 @@
+using DbProxy.Auth;
+
+namespace DbProxy.Tests.Unit;
+
+public class SessionManagerTests : IDisposable
+{
+    private readonly SessionManager _manager = new(TimeSpan.FromMinutes(5));
+
+    public void Dispose() => _manager.Dispose();
+
+    private AgentSession CreateTestSession(string id = "sess_test", int? budget = null)
+    {
+        return _manager.CreateSession(id, "agent", "task", budget, DateTime.UtcNow.AddHours(1));
+    }
+
+    [Fact]
+    public void IncrementQueryCount_NoBudget_AlwaysReturnsTrue()
+    {
+        CreateTestSession(budget: null);
+
+        for (int i = 0; i < 100; i++)
+            Assert.True(_manager.IncrementQueryCount("sess_test"));
+    }
+
+    [Fact]
+    public void IncrementQueryCount_WithBudget_AllowsUpToBudget()
+    {
+        CreateTestSession(budget: 5);
+
+        for (int i = 0; i < 5; i++)
+            Assert.True(_manager.IncrementQueryCount("sess_test"));
+    }
+
+    [Fact]
+    public void IncrementQueryCount_WithBudget_RejectsBeyondBudget()
+    {
+        CreateTestSession(budget: 3);
+
+        for (int i = 0; i < 3; i++)
+            _manager.IncrementQueryCount("sess_test");
+
+        Assert.False(_manager.IncrementQueryCount("sess_test"));
+    }
+
+    [Fact]
+    public void IncrementQueryCount_WithBudget_DoesNotOvercount()
+    {
+        var session = CreateTestSession(budget: 5);
+
+        for (int i = 0; i < 5; i++)
+            _manager.IncrementQueryCount("sess_test");
+
+        // Rejected queries should not increment the counter
+        Assert.False(_manager.IncrementQueryCount("sess_test"));
+        Assert.False(_manager.IncrementQueryCount("sess_test"));
+        Assert.False(_manager.IncrementQueryCount("sess_test"));
+
+        Assert.Equal(5, session.QueriesUsed);
+    }
+
+    [Fact]
+    public void IncrementQueryCount_CountMatchesBudgetAtExhaustion()
+    {
+        var session = CreateTestSession(budget: 10);
+
+        int succeeded = 0;
+        for (int i = 0; i < 15; i++)
+        {
+            if (_manager.IncrementQueryCount("sess_test"))
+                succeeded++;
+        }
+
+        Assert.Equal(10, succeeded);
+        Assert.Equal(10, session.QueriesUsed);
+    }
+
+    [Fact]
+    public void IncrementQueryCount_UnknownSession_ReturnsFalse()
+    {
+        Assert.False(_manager.IncrementQueryCount("sess_nonexistent"));
+    }
+
+    [Fact]
+    public void GetRemainingBudget_DecreasesCorrectly()
+    {
+        CreateTestSession(budget: 5);
+
+        Assert.Equal(5, _manager.GetRemainingBudget("sess_test"));
+
+        _manager.IncrementQueryCount("sess_test");
+        Assert.Equal(4, _manager.GetRemainingBudget("sess_test"));
+
+        for (int i = 0; i < 4; i++)
+            _manager.IncrementQueryCount("sess_test");
+
+        Assert.Equal(0, _manager.GetRemainingBudget("sess_test"));
+
+        // Rejected queries shouldn't make it go negative
+        _manager.IncrementQueryCount("sess_test");
+        Assert.Equal(0, _manager.GetRemainingBudget("sess_test"));
+    }
+}


### PR DESCRIPTION
## Summary
- `IncrementQueryCount()` was incrementing `QueriesUsed` before checking the budget limit, so rejected over-budget queries still inflated the counter (dashboard showed "53 / 50")
- Fix: check `>= budget` first, only increment if within budget — counter now stops at exactly the budget limit
- Added 7 unit tests for `SessionManager.IncrementQueryCount()` covering budget enforcement, overcount prevention, and edge cases

## Test plan
- [x] 7 new unit tests for IncrementQueryCount behavior
- [x] All 104 tests pass (55 unit + 49 integration)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)